### PR TITLE
Set go version before run test in GitHub actions

### DIFF
--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -8,6 +8,10 @@ jobs:
   TestAndReport:
     runs-on: ubuntu-20.04
     steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: 1.16
       - uses: actions/checkout@v2.3.4
       - name: Test
         run: |


### PR DESCRIPTION
See the errors from the following screenshot:

![image](https://user-images.githubusercontent.com/1450685/130814951-4f1b10a4-f7db-4b24-8d50-a4202a4c948a.png)
