### PR TITLE
Export organization in BlueOceanClient

### DIFF
--- a/pkg/job/blueocean.go
+++ b/pkg/job/blueocean.go
@@ -9,13 +9,13 @@ import (
 // BlueOceanClient is client for operating pipelines via BlueOcean RESTful API.
 type BlueOceanClient struct {
 	core.JenkinsCore
-	organization string
+	Organization string
 }
 
 // Search searches jobs via the BlueOcean API
 func (boClient *BlueOceanClient) Search(name string, start, limit int) (items []JenkinsItem, err error) {
 	api := fmt.Sprintf("/blue/rest/search/?q=pipeline:*%s*;type:pipeline;organization:%s;excludedFromFlattening=jenkins.branch.MultiBranchProject,com.cloudbees.hudson.plugins.folder.AbstractFolder&filter=no-folders&start=%d&limit=%d",
-		name, boClient.organization, start, limit)
+		name, boClient.Organization, start, limit)
 	err = boClient.RequestWithData(http.MethodGet, api,
 		nil, nil, 200, &items)
 	return

--- a/pkg/job/blueocean_test.go
+++ b/pkg/job/blueocean_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Pipeline test via BlueOcean RESTful API", func() {
 		roundTripper = mhttp.NewMockRoundTripper(ctrl)
 		boClient.RoundTripper = roundTripper
 		boClient.URL = "http://localhost"
-		boClient.organization = organization
+		boClient.Organization = organization
 	})
 
 	AfterEach(func() {

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -46,7 +46,7 @@ func (q *Client) Search(name, kind string, start, limit int) (items []JenkinsIte
 //
 // Deprecated: For clearer client of BlueOcean, please use BlueOceanClient#Search instead
 func (q *Client) SearchViaBlue(name string, start, limit int) (items []JenkinsItem, err error) {
-	boClient := BlueOceanClient{JenkinsCore: q.JenkinsCore, organization: "jenkins"}
+	boClient := BlueOceanClient{JenkinsCore: q.JenkinsCore, Organization: "jenkins"}
 	return boClient.Search(name, start, limit)
 }
 


### PR DESCRIPTION
### What this PR dose

Export organization in BlueOceanClient.

### Why we need it

When we create a BlueOceanClient, we have to set organization before we use the client. So we have to export the field.