### PR TITLE
Fix wrong parameters' payload

### DIFF
--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -21,6 +21,7 @@ jobs:
         run: |
           go test ./... -coverprofile coverage.out
       - name: Report
+        if: ${{ github.ref == 'refs/heads/main' }}
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |

--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -1,8 +1,12 @@
 name: Coverage Report
 
 on:
-  - push
-  - release
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   TestAndReport:

--- a/pkg/core/requestmatcher.go
+++ b/pkg/core/requestmatcher.go
@@ -54,25 +54,16 @@ func (request *RequestMatcher) Matches(x interface{}) bool {
 
 	if match {
 		match = matchHeader(request.request.Header, request.target.Header)
-		if !match {
-			Logger.Debug(fmt.Sprintf("got header: %v, want header %v", request.target.Header, request.request.Header))
-		}
 	}
 
 	if request.matchOptions.withQuery && match {
 		match = request.request.URL.RawQuery == target.URL.RawQuery
-		if !match {
-			Logger.Debug(fmt.Sprintf("got raw query: %s, want raw query: %s", request.target.URL.RawQuery, request.request.URL.RawQuery))
-		}
 	}
 
 	if request.matchOptions.withBody && match {
 		reqBody, _ := getStrFromReader(request.request)
 		targetBody, _ := getStrFromReader(target)
 		match = reqBody == targetBody
-		if !match {
-			Logger.Debug(fmt.Sprintf("got body: %s, want body: %s", targetBody, reqBody))
-		}
 	}
 
 	return match

--- a/pkg/core/requestmatcher.go
+++ b/pkg/core/requestmatcher.go
@@ -50,20 +50,29 @@ func (request *RequestMatcher) Matches(x interface{}) bool {
 	request.target = target
 
 	match := request.request.Method == target.Method && (request.request.URL.Path == target.URL.Path ||
-		request.request.URL.Path == target.URL.Opaque)
+		request.request.URL.Opaque == target.URL.Opaque)
 
 	if match {
 		match = matchHeader(request.request.Header, request.target.Header)
+		if !match {
+			Logger.Debug(fmt.Sprintf("got header: %v, want header %v", request.target.Header, request.request.Header))
+		}
 	}
 
 	if request.matchOptions.withQuery && match {
 		match = request.request.URL.RawQuery == target.URL.RawQuery
+		if !match {
+			Logger.Debug(fmt.Sprintf("got raw query: %s, want raw query: %s", request.target.URL.RawQuery, request.request.URL.RawQuery))
+		}
 	}
 
 	if request.matchOptions.withBody && match {
 		reqBody, _ := getStrFromReader(request.request)
 		targetBody, _ := getStrFromReader(target)
 		match = reqBody == targetBody
+		if !match {
+			Logger.Debug(fmt.Sprintf("got body: %s, want body: %s", targetBody, reqBody))
+		}
 	}
 
 	return match

--- a/pkg/job/blueocean.go
+++ b/pkg/job/blueocean.go
@@ -43,7 +43,7 @@ func (c *BlueOceanClient) Build(buildOption BuildOption) (*PipelineBuild, error)
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	var payloadReader io.Reader = nil
+	var payloadReader io.Reader
 	if len(buildOption.Parameters) > 0 {
 		// ignore this error due to never happened
 		payloadBytes, _ := json.Marshal(map[string][]Parameter{

--- a/pkg/job/blueocean.go
+++ b/pkg/job/blueocean.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/jenkins-zh/jenkins-client/pkg/core"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -21,10 +22,10 @@ type Parameter struct {
 }
 
 // Search searches jobs via the BlueOcean API
-func (boClient *BlueOceanClient) Search(name string, start, limit int) (items []JenkinsItem, err error) {
+func (c *BlueOceanClient) Search(name string, start, limit int) (items []JenkinsItem, err error) {
 	api := fmt.Sprintf("/blue/rest/search/?q=pipeline:*%s*;type:pipeline;organization:%s;excludedFromFlattening=jenkins.branch.MultiBranchProject,com.cloudbees.hudson.plugins.folder.AbstractFolder&filter=no-folders&start=%d&limit=%d",
-		name, boClient.Organization, start, limit)
-	err = boClient.RequestWithData(http.MethodGet, api,
+		name, c.Organization, start, limit)
+	err = c.RequestWithData(http.MethodGet, api,
 		nil, nil, 200, &items)
 	return
 }
@@ -36,18 +37,22 @@ type BuildOption struct {
 }
 
 // Build builds a pipeline for specific organization and pipelines.
-func (boClient *BlueOceanClient) Build(buildOption BuildOption) (*PipelineBuild, error) {
-	api := fmt.Sprintf("/blue/rest/organizations/%s/%s/runs/", boClient.Organization, ParsePipelinePath(buildOption.Pipelines...))
+func (c *BlueOceanClient) Build(buildOption BuildOption) (*PipelineBuild, error) {
+	api := fmt.Sprintf("/blue/rest/organizations/%s/%s/runs/", c.Organization, ParsePipelinePath(buildOption.Pipelines...))
 	var pb PipelineBuild
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	if buildOption.Parameters == nil {
-		buildOption.Parameters = make([]Parameter, 0)
+	var payloadReader io.Reader = nil
+	if len(buildOption.Parameters) > 0 {
+		// ignore this error due to never happened
+		payloadBytes, _ := json.Marshal(map[string][]Parameter{
+			"parameters": buildOption.Parameters,
+		})
+		payloadReader = strings.NewReader(string(payloadBytes))
 	}
-	// ignore this error due to never happened
-	payloadBytes, _ := json.Marshal(buildOption.Parameters)
-	err := boClient.RequestWithData(http.MethodPost, api, headers, strings.NewReader(string(payloadBytes)), 200, &pb)
+
+	err := c.RequestWithData(http.MethodPost, api, headers, payloadReader, 200, &pb)
 	if err != nil {
 		return nil, err
 	}
@@ -55,13 +60,13 @@ func (boClient *BlueOceanClient) Build(buildOption BuildOption) (*PipelineBuild,
 }
 
 // GetBuild gets build result for specific organization, run ID and pipelines.
-func (boClient *BlueOceanClient) GetBuild(runID string, pipelines ...string) (*PipelineBuild, error) {
-	api := fmt.Sprintf("/blue/rest/organizations/%s/%s/runs/%s/", boClient.Organization, ParsePipelinePath(pipelines...), runID)
+func (c *BlueOceanClient) GetBuild(runID string, pipelines ...string) (*PipelineBuild, error) {
+	api := fmt.Sprintf("/blue/rest/organizations/%s/%s/runs/%s/", c.Organization, ParsePipelinePath(pipelines...), runID)
 	var pb PipelineBuild
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	err := boClient.RequestWithData(http.MethodGet, api, headers, nil, 200, &pb)
+	err := c.RequestWithData(http.MethodGet, api, headers, nil, 200, &pb)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What this PR dose

Fix wrong parameters' payload

### Why we need it

Before:

```json
[{"name": "n", "value": "v"}]
```

Fixed according to https://github.com/jenkinsci/blueocean-plugin/tree/master/blueocean-rest#start-a-parameterized-build

```json
{
  "parameters" : [{
    "name" : "param1",
    "value" : "def"
  }]
}
```

