### PR TITLE
Remove contributors in the release draft

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -45,5 +45,3 @@ template: |
   ## What’s Changed
 
   $CHANGES
-
-  Thanks again to $CONTRIBUTORS! 🎉


### PR DESCRIPTION
GitHub can show the contributors by itself now

See

![image](https://user-images.githubusercontent.com/1450685/133534842-221c679e-69f0-43c0-b774-4088a0bc8c36.png)
