### PR TITLE
Allow to pass an empty parameters option

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Run go mod tidy on root modules
         run: go mod tidy
       # If there are any diffs from go mod tidy, fail.
-      - name: Verify no changes from goimports and go mod tidy.
+      - name: Verify no changes from go mod tidy.
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             echo 'To fix this check, run "go mod tidy"'
@@ -29,11 +29,20 @@ jobs:
             git status # Show the files that failed to pass the check.
             exit 1
           fi
+      - name: Run make fmt on root modules
+        run: make fmt
+      - name: Verify on changes from make fmt
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo 'To fix this check, run "make fmt"'
+            git diff
+            git status # Show the files that failed to pass the check.
+            exit 1
+          fi
       - name: golint
         uses: golangci/golangci-lint-action@v2
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.41.1
+          version: v1.42.1
           skip-build-cache: true
           skip-pkg-cache: true
       - name: test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,3 +13,4 @@ run:
 linters:
   enable:
     - revive # replacement for golint
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -31,15 +31,17 @@ help: ## Display this help.
 
 ##@ Development
 
-fmt: ## Run go fmt against code.
-	go fmt ./...
+GOIMPORTS=$(shell pwd)/bin/goimports
+fmt: ## Run goimports against code.
+	$(call go-get-tool,$(GOIMPORTS),golang.org/x/tools/cmd/goimports@latest)
+	$(GOIMPORTS) -w .
 
 vet: ## Run go vet against code.
 	go vet ./...
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 lint: ## Run golangci-lint against codes.
-	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1)
+	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1)
 	$(GOLANGCI_LINT) run
 
 test: fmt vet ## Run tests.

--- a/pkg/artifact/artifacts.go
+++ b/pkg/artifact/artifacts.go
@@ -2,9 +2,10 @@ package artifact
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"github.com/jenkins-zh/jenkins-client/pkg/job"
-	"net/http"
 )
 
 // Artifact represents the artifacts from Jenkins build

--- a/pkg/artifact/artifacts_test_common.go
+++ b/pkg/artifact/artifacts_test_common.go
@@ -3,10 +3,11 @@ package artifact
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
-	"github.com/jenkins-zh/jenkins-client/pkg/job"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
+	"github.com/jenkins-zh/jenkins-client/pkg/job"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 )

--- a/pkg/casc/casc.go
+++ b/pkg/casc/casc.go
@@ -1,8 +1,9 @@
 package casc
 
 import (
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"net/http"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 )
 
 // Manager is the client of configuration as code

--- a/pkg/casc/casc_test_common.go
+++ b/pkg/casc/casc_test_common.go
@@ -2,8 +2,9 @@ package casc
 
 import (
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"net/http"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 )

--- a/pkg/computer/computer.go
+++ b/pkg/computer/computer.go
@@ -3,12 +3,13 @@ package computer
 import (
 	"encoding/xml"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"runtime"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	httpdownloader "github.com/linuxsuren/http-downloader/pkg"
 )

--- a/pkg/computer/computer_test_common.go
+++ b/pkg/computer/computer_test_common.go
@@ -3,11 +3,12 @@ package computer
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 

--- a/pkg/core/test_methods.go
+++ b/pkg/core/test_methods.go
@@ -3,13 +3,14 @@ package core
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
 	"path/filepath"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 )
 
 // PrepareForEmptyAvaiablePluginList only for test

--- a/pkg/credential/credentials.go
+++ b/pkg/credential/credentials.go
@@ -3,10 +3,11 @@ package credential
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	httpdownloader "github.com/linuxsuren/http-downloader/pkg"
 	"go.uber.org/zap"

--- a/pkg/credential/credentials_test_common.go
+++ b/pkg/credential/credentials_test_common.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 

--- a/pkg/job/blueocean.go
+++ b/pkg/job/blueocean.go
@@ -56,7 +56,8 @@ type BuildOption struct {
 func (c *BlueOceanClient) Build(option BuildOption) (*PipelineRun, error) {
 	var pr PipelineRun
 	var payloadReader io.Reader
-	if len(option.Parameters) > 0 {
+	// we allow developers to pass an empty parameters, but nil parameters
+	if option.Parameters != nil {
 		// ignore this error due to never happened
 		payloadBytes, _ := json.Marshal(map[string][]Parameter{
 			"parameters": option.Parameters,

--- a/pkg/job/blueocean.go
+++ b/pkg/job/blueocean.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+
 	"strings"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/core"

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
-	httpdownloader "github.com/linuxsuren/http-downloader/pkg"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -15,6 +13,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
+	httpdownloader "github.com/linuxsuren/http-downloader/pkg"
 
 	"go.uber.org/zap"
 	"moul.io/http2curl"

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -3,12 +3,13 @@ package job
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 

--- a/pkg/job/job_test_common.go
+++ b/pkg/job/job_test_common.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 

--- a/pkg/job/status.go
+++ b/pkg/job/status.go
@@ -1,8 +1,9 @@
 package job
 
 import (
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"net/http"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 )
 
 // AgentLabel represents the label of Jenkins agent

--- a/pkg/job/status_test_common.go
+++ b/pkg/job/status_test_common.go
@@ -3,9 +3,10 @@ package job
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 )

--- a/pkg/plugin/pluginApi.go
+++ b/pkg/plugin/pluginApi.go
@@ -4,12 +4,13 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"path"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/util"
 

--- a/pkg/plugin/pluginApi_test_common.go
+++ b/pkg/plugin/pluginApi_test_common.go
@@ -3,9 +3,10 @@ package plugin
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 )

--- a/pkg/plugin/pluginManager_test.go
+++ b/pkg/plugin/pluginManager_test.go
@@ -3,9 +3,10 @@ package plugin
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 

--- a/pkg/plugin/pluginManager_test_common.go
+++ b/pkg/plugin/pluginManager_test_common.go
@@ -3,9 +3,10 @@ package plugin
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 )

--- a/pkg/plugin/pluginManger.go
+++ b/pkg/plugin/pluginManger.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -11,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	httpdownloader "github.com/linuxsuren/http-downloader/pkg"
 )

--- a/pkg/plugin/updateCenter.go
+++ b/pkg/plugin/updateCenter.go
@@ -2,10 +2,11 @@ package plugin
 
 import (
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	httpdownloader "github.com/linuxsuren/http-downloader/pkg"
 )

--- a/pkg/plugin/updateCenter_test.go
+++ b/pkg/plugin/updateCenter_test.go
@@ -3,10 +3,11 @@ package plugin
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"net/http"
 	"os"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/golang/mock/gomock"
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"

--- a/pkg/plugin/updateCenter_test_common.go
+++ b/pkg/plugin/updateCenter_test_common.go
@@ -2,10 +2,11 @@ package plugin
 
 import (
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 	httpdownloader "github.com/linuxsuren/http-downloader/pkg"

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -2,8 +2,9 @@ package queue
 
 import (
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"net/http"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 )
 
 // Client is the client of queue

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -3,11 +3,12 @@ package user
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/util"
 

--- a/pkg/user/user_test_common.go
+++ b/pkg/user/user_test_common.go
@@ -3,11 +3,12 @@ package user
 import (
 	"bytes"
 	"fmt"
-	"github.com/jenkins-zh/jenkins-client/pkg/core"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jenkins-zh/jenkins-client/pkg/core"
 
 	"github.com/jenkins-zh/jenkins-client/pkg/mock/mhttp"
 	httpdownloader "github.com/linuxsuren/http-downloader/pkg"


### PR DESCRIPTION
### What this PR dose

- Allow developers to pass an empty parameters, but nil parameters
- Add tests against it
- Rearrange imports using [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports)

### Why we need it

If we want to trigger a pipeline every time, we can pass an empty parameters option to Jenkins client. Currently, we have no chance to do that.

