### PR TITLE
Add MarshalJSON method for job.time type

### DIFF
--- a/pkg/job/time.go
+++ b/pkg/job/time.go
@@ -27,10 +27,28 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &timeStr); err != nil {
 		return err
 	}
+	// parse using Jenkins time layout first
 	parsedTime, err := time.Parse(jenkinsTimeLayout, timeStr)
 	if err != nil {
+		// parse using RFC3339 layout corresponding to MarshalJSON the timeStr isn't sufficient Jenkins time layout
+		parsedTime, err = time.Parse(time.RFC3339, timeStr)
+	}
+	if err != nil {
+		// return error if we tried the above methods
 		return err
 	}
 	t.Time = parsedTime.Local()
 	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (t *Time) MarshalJSON() ([]byte, error) {
+	if t.IsZero() {
+		return []byte("null"), nil
+	}
+	buf := make([]byte, 0, len(time.RFC3339)+2)
+	buf = append(buf, '"')
+	buf = t.UTC().AppendFormat(buf, time.RFC3339)
+	buf = append(buf, '"')
+	return buf, nil
 }

--- a/pkg/job/time_test.go
+++ b/pkg/job/time_test.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -21,6 +22,12 @@ func TestTime_UnmarshalJSON(t1 *testing.T) {
 			data: []byte(`"2021-08-23T17:03:04.144+0000"`),
 		},
 		want: time.Date(2021, 8, 23, 17, 3, 4, 144000000, time.UTC).Local(),
+	}, {
+		name: "RFC3339 time",
+		args: args{
+			data: []byte(`"2021-10-08T09:08:21.523Z"`),
+		},
+		want: time.Date(2021, 10, 8, 9, 8, 21, 523000000, time.UTC).Local(),
 	}, {
 		name: "null time",
 		args: args{
@@ -54,6 +61,53 @@ func TestTime_UnmarshalJSON(t1 *testing.T) {
 	}
 }
 
+func TestTime_Marshaler(t *testing.T) {
+	tests := []struct {
+		name    string
+		time    string
+		wantErr bool
+	}{{
+		name: "Jenkins time layout",
+		time: `"2021-08-23T17:03:04.144+0000"`,
+	}, {
+		name: "RFC3339 layout",
+		time: `"2021-10-08T09:08:21.523Z"`,
+	}, {
+		name:    "Invalid time",
+		time:    `"2021-10-09"`,
+		wantErr: true,
+	}, {
+		name: "Null time",
+		time: `null`,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			time := &Time{}
+			var err error
+			if err = json.Unmarshal([]byte(tt.time), time); (err != nil) != tt.wantErr {
+				t.Errorf("Failed to unmarshal the time: %v, and error = %v", tt.time, err)
+			}
+			if err != nil {
+				// skip if error was occurred before
+				return
+			}
+			var timeBytes []byte
+			timeBytes, err = json.Marshal(time)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Failed to marshal the time: %v, and error = %v", time, err)
+			}
+			if err != nil {
+				// skip if error was occurred before
+				return
+			}
+			if err := json.Unmarshal(timeBytes, time); (err != nil) != tt.wantErr {
+				t.Errorf("Failed to unmarshal the time: %v, and error = %v", string(timeBytes), err)
+			}
+		})
+	}
+}
+
 func TestTime_IsZero(t1 *testing.T) {
 	tests := []struct {
 		name string
@@ -77,6 +131,60 @@ func TestTime_IsZero(t1 *testing.T) {
 		t1.Run(tt.name, func(t1 *testing.T) {
 			if got := tt.time.IsZero(); got != tt.want {
 				t1.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTime_MarshalJSON(t *testing.T) {
+	gmtZone, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Errorf("unable to prepare GMT zone, error = %v", err)
+	}
+
+	type fields struct {
+		Time time.Time
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []byte
+		wantErr bool
+	}{{
+		name: "UTC time",
+		fields: fields{
+			Time: time.Date(2021, 10, 9, 15, 23, 59, 123456789, time.UTC),
+		},
+		want: []byte(`"2021-10-09T15:23:59Z"`),
+	}, {
+		name: "GTM time",
+		fields: fields{
+			Time: time.Date(2021, 10, 9, 15, 23, 59, 123456789, gmtZone),
+		},
+		want: []byte(`"2021-10-09T07:23:59Z"`),
+	}, {
+		name:   "Nil time",
+		fields: fields{},
+		want:   []byte("null"),
+	}, {
+		name: "Zero time",
+		fields: fields{
+			Time: time.Time{},
+		},
+		want: []byte("null"),
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &Time{
+				Time: tt.fields.Time,
+			}
+			got, err := tr.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Time.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Time.MarshalJSON() = %s, want %s", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
### What this PR dose?

- Add MarshalJSON method for job.time type
- Make sure that UnMarshalJSON supports to parse time using Jenkins time layout and RFC3339 time layout

### Why we need it

Before doing this, we cannot deserialize time string which is serialized by `job.Time`. Because the time layouts used by deserialization and serialization are different. Jenkins time layout is used by deserialization, but RFC3339 time layout is used by serialization by default. So we will get the following error when we trying to deserialize the time string:

```log
parsing time "2021-09-28T03:40:11.253Z" as "2006-01-02T15:04:05.000-0700": cannot parse "Z" as "-0700"
```

/kind bug