### PR TITLE
Correct tpye of field ArtifactsZipFile

### DIFF
--- a/pkg/job/blueocean_type.go
+++ b/pkg/job/blueocean_type.go
@@ -5,7 +5,7 @@ import "fmt"
 // BlueItemRun contains basic metadata of a build.
 // Reference: https://github.com/jenkinsci/blueocean-plugin/blob/a7cbc946b73d89daf9dfd91cd713cc7ab64a2d95/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueItemRun.java
 type BlueItemRun struct {
-	ArtifactsZipFile          *BlueArtifact        `json:"artifactsZipFile,omitempty"`
+	ArtifactsZipFile          string               `json:"artifactsZipFile,omitempty"`
 	CauseOfBlockage           string               `json:"causeOfBlockage,omitempty"`
 	Causes                    []Cause              `json:"causes,omitempty"`
 	ChangeSet                 []BlueChangeSetEntry `json:"changeSet,omitempty"`


### PR DESCRIPTION
### What this PR dose?

Correct tpye of field ArtifactsZipFile from BlueArtifact to string.

### Why we need it?

Please see: https://github.com/jenkinsci/blueocean-plugin/blob/6b27be3724c892427b732f30575fdcc2977cfaef/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueItemRun.java#L104-L108

/kind bug