### PR TITLE
Refine ParameterDefinition and ParameterValue types

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -526,13 +526,12 @@ type ParametersDefinitionProperty struct {
 // ParameterDefinition holds the parameter definition
 // Reference: https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/ParameterDefinition.java#L98
 type ParameterDefinition struct {
-	Description string `json:"description,omitempty"`
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	Value       string `json:"value"`
-	// Filepath field dosen't belong to ParameterDefinition
-	Filepath              string         `json:"file,omitempty"`
-	DefaultParameterValue ParameterValue `json:"defaultParameterValue"`
+	Description           string          `json:"description,omitempty"`
+	Name                  string          `json:"name"`
+	Type                  string          `json:"type"`
+	Value                 string          `json:"value"`
+	Filepath              string          `json:"file,omitempty"`
+	DefaultParameterValue *ParameterValue `json:"defaultParameterValue,omitempty"`
 }
 
 // ParameterValue represents the value for param

--- a/pkg/job/job_test_common.go
+++ b/pkg/job/job_test_common.go
@@ -68,7 +68,7 @@ func PrepareForBuildWithNoParams(roundTripper *mhttp.MockRoundTripper, rootURL, 
 // PrepareForBuildWithParams only for test
 func PrepareForBuildWithParams(roundTripper *mhttp.MockRoundTripper, rootURL, jobName, user, password string) (
 	request *http.Request, response *http.Response) {
-	formData := url.Values{"json": {`{"parameter": {"Description":"","name":"name","Type":"StringParameterDefinition","value":"value","file":"","DefaultParameterValue":{"Description":"","Value":null}}}`}}
+	formData := url.Values{"json": {`{"parameter": {"name":"name","type":"StringParameterDefinition","value":"value"}}`}}
 	payload := strings.NewReader(formData.Encode())
 	request, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("%s/job/%s/build", rootURL, jobName), payload)
 	request.Header.Add(httpdownloader.ContentType, httpdownloader.ApplicationForm)


### PR DESCRIPTION
### What this PR dose?

- Add missing JSON tag for `ParameterDefinition` and `ParameterValue` types
- Correct inner fields of ParameterValue type

**References**:

- https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/ParameterDefinition.java#L98
- https://github.com/jenkinsci/jenkins/blob/f23512f2bc97d18cd4f0183a7db4a62bc6b84196/core/src/main/java/hudson/model/ParameterValue.java#L78

/kind bug