### PR TITLE
Escape special character for branch parameter

### DIFF
--- a/pkg/job/blueocean.go
+++ b/pkg/job/blueocean.go
@@ -235,7 +235,7 @@ func (c *BlueOceanClient) getGetStepsAPI(option *GetStepsOption) string {
 	// api := c.getGetPipelineAPI(pipelineName, folders...)
 	api := c.getGetPipelineAPI(option.PipelineName, option.Folders...)
 	if option.Branch != "" {
-		api = api + "/branches/" + option.Branch
+		api = api + "/branches/" + url.PathEscape(option.Branch)
 	}
 	api = api + "/runs/" + option.RunID
 	if option.NodeID != "" {

--- a/pkg/job/blueocean_test.go
+++ b/pkg/job/blueocean_test.go
@@ -706,6 +706,18 @@ var _ = Describe("SimplePipeline test via BlueOcean RESTful API", func() {
 			Expect(steps).NotTo(BeNil())
 			Expect(len(steps)).To(Equal(0))
 		})
+		It("Without folder but with branch with special character", func() {
+			option := GetStepsOption{
+				RunID:        "123",
+				PipelineName: "pipelineA",
+				Branch:       "release%2Fv3.2",
+			}
+			given("/blue/rest/organizations/jenkins/pipelines/pipelineA/branches/release%252Fv3.2/runs/123/steps/", 200, "[]")
+			steps, err := c.GetSteps(option)
+			Expect(err).To(Succeed())
+			Expect(steps).NotTo(BeNil())
+			Expect(len(steps)).To(Equal(0))
+		})
 		It("With one folder and branch", func() {
 			option := GetStepsOption{
 				RunID:        "123",
@@ -754,7 +766,6 @@ var _ = Describe("SimplePipeline test via BlueOcean RESTful API", func() {
 			Expect(steps).NotTo(BeNil())
 			Expect(len(steps)).To(Equal(0))
 		})
-
 	})
 
 	Context("GetBranches", func() {


### PR DESCRIPTION
### What this PR dose

Escape special character for branch parameter while getting steps data.

### Why we need it

Considering the branch named `release%2Fv3.2`, Jenkins client will create a request with url `/blue/rest/organizations/jenkins/pipelines/pipelineA/branches/release%2Fv3.2/runs/123/steps/`(equal to `/blue/rest/organizations/jenkins/pipelines/pipelineA/branches/release/v3.2/runs/123/steps/`) while getting steps data. 

`/blue/rest/organizations/jenkins/pipelines/pipelineA/branches/release%252Fv3.2/runs/123/steps/` is what we expect. See also in BlueOcean Dashboard:
![image](https://user-images.githubusercontent.com/16865714/144742751-5b4318f4-729c-425f-b5f9-a2b82dfbd602.png)
