### PR TITLE
Fix json form in UpdateInFolder

### DIFF
--- a/pkg/credential/credentials.go
+++ b/pkg/credential/credentials.go
@@ -75,7 +75,7 @@ func (c *CredentialsManager) UpdateInFolder(folder, id string, cre interface{}) 
 	api := fmt.Sprintf("/job/%s/credentials/store/folder/domain/_/credential/%s/updateSubmit", folder, id)
 
 	formData := url.Values{}
-	formData.Add("json", fmt.Sprintf(`{"credentials": %s}`, util.TOJSON(cre)))
+	formData.Add("json", util.TOJSON(cre))
 
 	request := core.NewRequest(api, &c.JenkinsCore)
 	request.AsPostFormRequest().WithValues(formData).AcceptStatusCode(http.StatusNotFound)

--- a/pkg/credential/credentials_test.go
+++ b/pkg/credential/credentials_test.go
@@ -165,7 +165,7 @@ func TestUpdateInFolder(t *testing.T) {
 			roundTripper := mhttp.NewMockRoundTripper(ctrl)
 
 			formData := url.Values{}
-			formData.Add("json", fmt.Sprintf(`{"credentials": %s}`, util.TOJSON(obj)))
+			formData.Add("json", util.TOJSON(obj))
 			payload := strings.NewReader(formData.Encode())
 
 			manager.URL = "http://localhost"

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -19,7 +19,7 @@ func URLJoin(host, api string) (targetURL *url.URL, err error) {
 	return
 }
 
-//URLJoinAsString  is an util function to join host URL and API URL
+// URLJoinAsString  is an util function to join host URL and API URL
 func URLJoinAsString(host, api string) (targetURLStr string, err error) {
 	var targetURL *url.URL
 	if targetURL, err = URLJoin(host, api); err == nil {


### PR DESCRIPTION
change the json payload that in the UpdateInFolder function
from
```json
{
    "credentials":{
        "description":"",
        "DisplayName":"",
        "Fingerprint":null,
        "FullName":"",
        "id":"gitee",
        "TypeName":"",
        "$class":"com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl",
        "stapler-class":"com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl",
        "scope":"GLOBAL",
        "username":"chengleqi",
        "password":"xxx"
    }
}
```
to
```json
{
    "description":"",
    "DisplayName":"",
    "Fingerprint":null,
    "FullName":"",
    "id":"gitee",
    "TypeName":"",
    "$class":"com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl",
    "stapler-class":"com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl",
    "scope":"GLOBAL",
    "username":"chengleqi",
    "password":"xxx"
}
```