### PR TITLE
fix(core): add cookie handling to support Jenkins newer versions requiring session cookies for API access

### DIFF
--- a/pkg/core/common.go
+++ b/pkg/core/common.go
@@ -43,6 +43,8 @@ type JenkinsCore struct {
 	Debug        bool
 	Output       io.Writer
 	RoundTripper http.RoundTripper
+
+	Cookies []*http.Cookie
 }
 
 // JenkinsCrumb crumb for Jenkins
@@ -381,6 +383,10 @@ func (j *JenkinsCore) Request(method, api string, headers map[string]string, pay
 		return
 	}
 
+	for _, c := range j.Cookies {
+		req.AddCookie(c)
+	}
+
 	for k, v := range headers {
 		req.Header.Add(k, v)
 	}
@@ -391,6 +397,9 @@ func (j *JenkinsCore) Request(method, api string, headers map[string]string, pay
 
 	client := j.GetClient()
 	if response, err = client.Do(req); err == nil {
+		if len(response.Cookies()) > 0 {
+			j.Cookies = response.Cookies()
+		}
 		statusCode = response.StatusCode
 		data, err = ioutil.ReadAll(response.Body)
 	}


### PR DESCRIPTION
Jenkins newer versions enforce stricter authentication and CSRF protection.
API calls without cookies (e.g., JSESSIONID) may be rejected with 403 errors even with valid BasicAuth.
This commit adds automatic cookie persistence — saving cookies from Jenkins responses and reattaching them in subsequent requests.
